### PR TITLE
Unify plural argument naming & add aliases

### DIFF
--- a/countryfetch/src/args.rs
+++ b/countryfetch/src/args.rs
@@ -74,23 +74,23 @@ pub struct Args {
     /// Exclude population
     #[arg(long, help_heading = "Config")]
     pub no_population: bool,
-    /// Exclude top-level domain
-    #[arg(long, help_heading = "Config")]
-    pub no_tld: bool,
+    /// Exclude top-level domains
+    #[arg(long, help_heading = "Config", alias = "no-tld")]
+    pub no_tlds: bool,
     /// Exclude languages
-    #[arg(long, help_heading = "Config")]
+    #[arg(long, help_heading = "Config", alias = "no-language")]
     pub no_languages: bool,
-    /// Exclude currency
-    #[arg(long, help_heading = "Config")]
-    pub no_currency: bool,
+    /// Exclude currencies
+    #[arg(long, help_heading = "Config", alias = "no-currency")]
+    pub no_currencies: bool,
     /// Exclude neighbours
-    #[arg(long, help_heading = "Config")]
+    #[arg(long, help_heading = "Config", aliases = ["no-neighbour", "no-neighbors", "no-neighbor"])]
     pub no_neighbours: bool,
     /// Exclude established date
     #[arg(long, help_heading = "Config")]
     pub no_established_date: bool,
     /// Exclude iso codes
-    #[arg(long, help_heading = "Config")]
+    #[arg(long, help_heading = "Config", alias = "no-iso-code")]
     pub no_iso_codes: bool,
     /// Exclude driving side
     #[arg(long, help_heading = "Config")]

--- a/countryfetch/src/country_format.rs
+++ b/countryfetch/src/country_format.rs
@@ -336,7 +336,7 @@ pub fn format_country(
             .filter(|_| (!args.no_continent)),
         population: (!args.no_population)
             .then_some(country.map_or(gen_country.population(), |c| c.population)),
-        top_level_domain: (!args.no_tld).then_some(&country.map_or_else(
+        top_level_domain: (!args.no_tlds).then_some(&country.map_or_else(
             || {
                 gen_country
                     .top_level_domain()
@@ -356,7 +356,7 @@ pub fn format_country(
             },
             |c| c.languages.clone().into_values().collect(),
         )),
-        currency: (!args.no_currency).then_some((
+        currency: (!args.no_currencies).then_some((
             gen_country::currency_position(gen_country),
             country.map_or_else(
                 || {


### PR DESCRIPTION
I made the field names plural where appropriate, and added CLI (invisible) aliases both for completeness and for backward compatibility.