### PR TITLE
Switch to Rust stable

### DIFF
--- a/countryfetch/src/args.rs
+++ b/countryfetch/src/args.rs
@@ -134,10 +134,12 @@ You can either use the country name, or the 2-letter country code. Case-insensit
                 let out = format_country(*country, None, None, &self);
                 println!("{out}");
             }
-        } else if let Some(countries) = &self.country
-            && !countries.is_empty()
+        } else if let Some(countries) = &self
+            .country
+            .as_ref()
+            .and_then(|v| (!v.is_empty()).then_some(v))
         {
-            for country in countries {
+            for country in *countries {
                 let out = format_country(*country, None, None, &self);
                 println!("{out}");
             }

--- a/countryfetch/src/lib.rs
+++ b/countryfetch/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(let_chains)]
 #![allow(clippy::multiple_crate_versions, reason = "todo")]
 #![allow(clippy::cargo_common_metadata, reason = "later")]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"


### PR DESCRIPTION
Removes the unstable `let_chains` feature by refactoring the code
which enables the use of stable Rust.

Fixes #12
