### PR TITLE
Update Porutgal establishment date in extras.rs

### DIFF
--- a/gen_country/src/extras.rs
+++ b/gen_country/src/extras.rs
@@ -265,7 +265,7 @@ pub fn established_date(country: Country) -> &'static str {
         Country::Philippines => "June 12, 1898",
         Country::PitcairnIslands => "January 15, 1790",
         Country::Poland => "November 11, 1918",
-        Country::Portugal => "June 10, 1580",
+        Country::Portugal => "October 5, 1143",
         Country::PuertoRico => "July 25, 1952",
         Country::Qatar => "September 3, 1971",
         Country::Reunion => "March 19, 1946",


### PR DESCRIPTION
First recognized in October 5, 1143.
Later confirmed confirmed by the pope in 1179.
This was only interrupted by the Iberian Union (1580–1640). From Kindgom to Consitutional Republic in 1910.

Source: https://ue.missaoportugal.mne.gov.pt/pt/portugal/sobre-portugal/historia