### PR TITLE
Add Liberland project-local country entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Add a generated Liberland entry with project-local `LL` / `LIB` codes for explicit lookups
+- Skip blank output sections so entries without capital, dialing code, or TLD metadata render cleanly
+
 # v0.1.9 - 7 March 2025
 
 - Use `,` instead of `OR` as a separator in `--list-countries`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ You can also use 2-letter country codes:
 countryfetch us gb
 ```
 
+Project-specific aliases can also cover entries that are not part of the
+default Rest Countries dataset:
+
+```sh
+countryfetch Liberland
+countryfetch ll
+```
+
 List all countries:
 
 ```sh

--- a/countryfetch/src/args.rs
+++ b/countryfetch/src/args.rs
@@ -177,3 +177,24 @@ You can either use the country name, or the 2-letter country code. Case-insensit
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    use super::Args;
+
+    #[test]
+    fn parses_liberland_by_name() {
+        let args = Args::try_parse_from(["countryfetch", "Liberland"]).expect("valid country");
+        let countries = args.country.expect("country argument present");
+        assert_eq!(countries, vec![gen_country::Country::Liberland]);
+    }
+
+    #[test]
+    fn parses_liberland_by_project_code() {
+        let args = Args::try_parse_from(["countryfetch", "ll"]).expect("valid country alias");
+        let countries = args.country.expect("country argument present");
+        assert_eq!(countries, vec![gen_country::Country::Liberland]);
+    }
+}

--- a/countryfetch/src/country_format.rs
+++ b/countryfetch/src/country_format.rs
@@ -25,6 +25,7 @@ struct CountryOutput<'a> {
     currency: Currency,
     neighbours: Option<&'a Vec<String>>,
     established_date: Option<&'static str>,
+    status_note: Option<&'static str>,
     dialing_code: Option<String>,
     capital: Option<&'a Vec<String>>,
     driving_side: Option<&'a str>,
@@ -34,6 +35,31 @@ struct CountryOutput<'a> {
 }
 
 impl CountryOutput<'_> {
+    fn format_decimal(value: f64) -> String {
+        let rounded = (value * 100.0).round() / 100.0;
+        let trimmed = format!("{rounded:.2}")
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_owned();
+
+        let (integer, fraction) = trimmed
+            .split_once('.')
+            .map_or((trimmed.as_str(), None), |(integer, fraction)| {
+                (integer, Some(fraction))
+            });
+
+        let integer = integer
+            .parse::<u64>()
+            .expect("formatted decimal keeps a valid positive integer part")
+            .separated_string();
+
+        fraction.map_or(integer.clone(), |fraction| format!("{integer}.{fraction}"))
+    }
+
+    fn is_blank(value: &str) -> bool {
+        value.trim().is_empty()
+    }
+
     /// Applies the country's brightest color to the given text
     fn colored(&self, s: &str) -> colored::ColoredString {
         s.truecolor(
@@ -45,8 +71,8 @@ impl CountryOutput<'_> {
 
     fn area(&self) -> String {
         if let (Some(area_km), Some(area_mi)) = (self.area_km, self.area_mi) {
-            let km = area_km.separated_string();
-            let mi = area_mi.separated_string();
+            let km = Self::format_decimal(area_km);
+            let mi = Self::format_decimal(area_mi);
             format!("{}: {km} km² ({mi} miles²)\n", self.colored("Area"))
         } else {
             String::new()
@@ -65,6 +91,10 @@ impl CountryOutput<'_> {
 
     fn capital(&self) -> String {
         self.capital.map_or_else(String::new, |capital| {
+            if capital.is_empty() {
+                return String::new();
+            }
+
             format!(
                 "{}: {}\n",
                 self.colored(&format!(
@@ -80,6 +110,10 @@ impl CountryOutput<'_> {
         self.dialing_code
             .as_ref()
             .map_or_else(String::new, |dialing_code| {
+                if Self::is_blank(dialing_code) {
+                    return String::new();
+                }
+
                 format!("{}: {}\n", self.colored("Dialing code"), dialing_code)
             })
     }
@@ -88,6 +122,10 @@ impl CountryOutput<'_> {
         self.iso_codes
             .as_ref()
             .map_or_else(String::new, |iso_codes| {
+                if Self::is_blank(&iso_codes.0) || Self::is_blank(&iso_codes.1) {
+                    return String::new();
+                }
+
                 format!(
                     "{}: {} / {}\n",
                     self.colored("ISO Codes"),
@@ -105,35 +143,35 @@ impl CountryOutput<'_> {
 
     fn currency(&self) -> String {
         if let Some((currency_position, currencies)) = &self.currency {
+            if currencies.is_empty() {
+                return String::new();
+            }
+
             let currency_label = self.colored(&format!(
                 "Currenc{y}",
                 y = if currencies.len() == 1 { "y" } else { "ies" }
             ));
 
-            match currency_position {
-                CurrencyPosition::Left => {
-                    format!(
-                        "{}: {}\n",
-                        currency_label,
-                        currencies
-                            .iter()
-                            .map(|(id, name, symbol)| format!("{symbol} {id} ({name})"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
+            let format_currency = |(id, name, symbol): &(String, String, String)| {
+                if Self::is_blank(symbol) || symbol == id {
+                    format!("{id} ({name})")
+                } else {
+                    match currency_position {
+                        CurrencyPosition::Left => format!("{symbol} {id} ({name})"),
+                        CurrencyPosition::Right => format!("{id} {symbol} ({name})"),
+                    }
                 }
-                CurrencyPosition::Right => {
-                    format!(
-                        "{}: {}\n",
-                        currency_label,
-                        currencies
-                            .iter()
-                            .map(|(id, name, symbol)| format!("{id} {symbol} ({name})"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
-                }
-            }
+            };
+
+            format!(
+                "{}: {}\n",
+                currency_label,
+                currencies
+                    .iter()
+                    .map(format_currency)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
         } else {
             String::new()
         }
@@ -153,6 +191,10 @@ impl CountryOutput<'_> {
 
     fn neighbours(&self) -> String {
         self.neighbours.map_or_else(String::new, |neighbours| {
+            if neighbours.is_empty() {
+                return String::new();
+            }
+
             let neigh = neighbours
                 .iter()
                 .filter_map(|cc3| {
@@ -180,6 +222,10 @@ impl CountryOutput<'_> {
 
     fn continent(&self) -> String {
         if let (Some(continent), continent_code) = (self.continent, self.continent_code) {
+            if continent.is_empty() {
+                return String::new();
+            }
+
             format!(
                 "{}: {}{}\n",
                 self.colored(&format!(
@@ -203,9 +249,19 @@ impl CountryOutput<'_> {
             })
     }
 
+    fn status_note(&self) -> String {
+        self.status_note.map_or_else(String::new, |status_note| {
+            format!("{}: {}\n", self.colored("Status"), status_note)
+        })
+    }
+
     fn top_level_domain(&self) -> String {
         self.top_level_domain
             .map_or_else(String::new, |top_level_domain| {
+                if top_level_domain.is_empty() {
+                    return String::new();
+                }
+
                 format!(
                     "{}: {}\n",
                     self.colored(&format!(
@@ -221,6 +277,10 @@ impl CountryOutput<'_> {
         self.languages
             .as_ref()
             .map_or_else(String::new, |languages| {
+                if languages.is_empty() {
+                    return String::new();
+                }
+
                 format!(
                     "{}: {}\n",
                     self.colored(&format!(
@@ -234,6 +294,7 @@ impl CountryOutput<'_> {
 
     fn flag(&self) -> String {
         self.flag_emoji
+            .filter(|flag| !Self::is_blank(flag))
             .map(|flag| format!(" {flag}"))
             .unwrap_or_default()
     }
@@ -260,6 +321,7 @@ impl CountryOutput<'_> {
             &self.dialing_code(),
             &self.languages(),
             &self.established_date(),
+            &self.status_note(),
             &self.currency(),
             &self.top_level_domain(),
             &self.palette(),
@@ -314,13 +376,13 @@ pub fn format_country(
         flag_emoji: (!args.no_emoji)
             .then_some(country.map_or(gen_country.emoji(), |c| c.emoji.as_str())),
         area_km: (!args.no_area).then_some(country.map_or(gen_country.area_km(), |c| c.area_km)),
-        // rounds to the nearest 100
-        area_mi: (!args.no_area).then_some((area_km * (0.62137_f64.powi(2)) * 0.01).round() / 0.01),
+        // rounds to 2 decimal places
+        area_mi: (!args.no_area)
+            .then_some((area_km * (0.62137_f64.powi(2)) * 100.0).round() / 100.0),
         country_name: country.map_or(
             gen_country.country_name(),
             super::country::Country::country_name,
         ),
-
         continent: (!args.no_continent).then_some(&country.map_or_else(
             || {
                 gen_country
@@ -333,7 +395,7 @@ pub fn format_country(
         )),
         continent_code: location
             .map(|l| l.continent_code.as_str())
-            .filter(|_| (!args.no_continent)),
+            .filter(|_| !args.no_continent),
         population: (!args.no_population)
             .then_some(country.map_or(gen_country.population(), |c| c.population)),
         top_level_domain: (!args.no_tlds).then_some(&country.map_or_else(
@@ -392,6 +454,7 @@ pub fn format_country(
         )),
         established_date: (!args.no_established_date)
             .then_some(gen_country::established_date(gen_country)),
+        status_note: gen_country::status_note(gen_country),
         iso_codes: (!args.no_iso_codes).then_some(country.map_or_else(
             || {
                 (
@@ -423,4 +486,80 @@ pub fn format_country(
         brightest_color: gen_country.brightest_color(),
     }
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_country;
+    use crate::Args;
+
+    fn strip_ansi(input: &str) -> String {
+        let mut output = String::new();
+        let mut chars = input.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            if ch == '\u{1b}' && chars.next_if_eq(&'[').is_some() {
+                while let Some(next) = chars.next() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                output.push(ch);
+            }
+        }
+
+        output
+    }
+
+    fn default_args() -> Args {
+        Args {
+            country: None,
+            all_countries: false,
+            list_countries: false,
+            no_area: false,
+            no_flag: true,
+            no_emoji: false,
+            no_continent: false,
+            no_population: false,
+            no_tlds: false,
+            no_languages: false,
+            no_currencies: false,
+            no_neighbours: false,
+            no_established_date: false,
+            no_iso_codes: false,
+            no_driving_side: false,
+            no_capital: false,
+            no_dialing_code: false,
+            no_palette: true,
+            no_color: true,
+        }
+    }
+
+    #[test]
+    fn liberland_output_includes_seeded_metadata() {
+        let output = format_country(gen_country::Country::Liberland, None, None, &default_args());
+        let output = strip_ansi(&output);
+
+        assert!(output.contains("Liberland"));
+        assert!(output.contains("Established: April 13, 2015"));
+        assert!(output.contains("Status: Self-proclaimed micronation"));
+        assert!(output.contains("disputed territory between Croatia and"));
+        assert!(output.contains("Area: 7 km² (2.7 miles²)"));
+        assert!(output.contains("Population: 63 People"));
+        assert!(output.contains("Neighbours: Croatia, Serbia"));
+        assert!(output.contains("Language: English"));
+        assert!(output.contains("Currency: LLD (Liberland dollar)"));
+        assert!(output.contains("ISO Codes: LL / LIB"));
+    }
+
+    #[test]
+    fn liberland_output_omits_unknown_fields() {
+        let output = format_country(gen_country::Country::Liberland, None, None, &default_args());
+        let output = strip_ansi(&output);
+
+        assert!(!output.contains("Capital:"));
+        assert!(!output.contains("Dialing code:"));
+        assert!(!output.contains("Top Level Domain:"));
+    }
 }

--- a/gen_country/src/extras.rs
+++ b/gen_country/src/extras.rs
@@ -37,6 +37,7 @@ pub fn currency_position(country: Country) -> CurrencyPosition {
         | Country::IsleOfMan
         | Country::Jersey
         | Country::Liberia
+        | Country::Liberland
         | Country::Malawi
         | Country::Namibia
         | Country::Nigeria
@@ -213,6 +214,7 @@ pub fn established_date(country: Country) -> &'static str {
         Country::Lebanon => "November 22, 1943",
         Country::Lesotho => "October 4, 1966",
         Country::Liberia => "July 26, 1847",
+        Country::Liberland => "April 13, 2015",
         Country::Libya => "December 24, 1951",
         Country::Liechtenstein => "July 23, 1806",
         Country::Lithuania => "February 16, 1918",
@@ -337,5 +339,14 @@ pub fn established_date(country: Country) -> &'static str {
         Country::Yemen => "May 22, 1990",
         Country::Zambia => "October 24, 1964",
         Country::Zimbabwe => "April 18, 1980",
+    }
+}
+
+pub fn status_note(country: Country) -> Option<&'static str> {
+    match country {
+        Country::Liberland => {
+            Some("Self-proclaimed micronation on disputed territory between Croatia and Serbia")
+        },
+        _ => None,
     }
 }

--- a/gen_country/src/lib.rs
+++ b/gen_country/src/lib.rs
@@ -260,6 +260,8 @@ pub enum Country {
     Lesotho,
     #[clap(alias = "LR")]
     Liberia,
+    #[clap(alias = "LL")]
+    Liberland,
     #[clap(alias = "LY")]
     Libya,
     #[clap(alias = "LI")]
@@ -639,6 +641,7 @@ impl Country {
         Country::Lebanon,
         Country::Lesotho,
         Country::Liberia,
+        Country::Liberland,
         Country::Libya,
         Country::Liechtenstein,
         Country::Lithuania,
@@ -892,6 +895,7 @@ impl Country {
             Self::Lebanon => Some(r###"The flag of Lebanon is composed of three horizontal bands of red, white and red. The white band is twice the height of the red bands and bears a green Lebanese Cedar tree at its center."###),
             Self::Lesotho => Some(r###"The flag of Lesotho is composed of three horizontal bands of blue, white and green in the ratio of 3:4:3. A black mokorotlo — a Basotho hat — is centered in the white band."###),
             Self::Liberia => Some(r###"The flag of Liberia is composed of eleven equal horizontal bands of red alternating with white. A blue square bearing a five-pointed white star is superimposed in the canton."###),
+            Self::Liberland => Some(r###"The flag of Liberland is composed of three horizontal stripes, black in the center between two yellow stripes, with the coat of arms centered."###),
             Self::Libya => Some(r###"The flag of Libya is composed of three horizontal bands of red, black and green, with the black band twice the height of the other two bands. At the center of the black band is a fly-side facing white crescent and a five-pointed white star placed just outside the crescent opening."###),
             Self::Liechtenstein => Some(r###"The flag of Liechtenstein is composed of two equal horizontal bands of blue and red, with a golden-yellow crown on the hoist side of the blue band."###),
             Self::Lithuania => Some(r###"The flag of Lithuania is composed of three equal horizontal bands of yellow, green and red."###),
@@ -1146,6 +1150,7 @@ impl Country {
             Self::Lebanon => r###"Lebanon"###,
             Self::Lesotho => r###"Lesotho"###,
             Self::Liberia => r###"Liberia"###,
+            Self::Liberland => r###"Liberland"###,
             Self::Libya => r###"Libya"###,
             Self::Liechtenstein => r###"Liechtenstein"###,
             Self::Lithuania => r###"Lithuania"###,
@@ -1400,6 +1405,7 @@ impl Country {
             Self::Lebanon => r###"LBN"###,
             Self::Lesotho => r###"LSO"###,
             Self::Liberia => r###"LBR"###,
+            Self::Liberland => r###"LIB"###,
             Self::Libya => r###"LBY"###,
             Self::Liechtenstein => r###"LIE"###,
             Self::Lithuania => r###"LTU"###,
@@ -1654,6 +1660,7 @@ impl Country {
             Self::Lebanon => r###"LB"###,
             Self::Lesotho => r###"LS"###,
             Self::Liberia => r###"LR"###,
+            Self::Liberland => r###"LL"###,
             Self::Libya => r###"LY"###,
             Self::Liechtenstein => r###"LI"###,
             Self::Lithuania => r###"LT"###,
@@ -1908,6 +1915,7 @@ impl Country {
             Self::Lebanon => &[".lb"],
             Self::Lesotho => &[".ls"],
             Self::Liberia => &[".lr"],
+            Self::Liberland => &[],
             Self::Libya => &[".ly"],
             Self::Liechtenstein => &[".li"],
             Self::Lithuania => &[".lt"],
@@ -2162,6 +2170,7 @@ impl Country {
             Self::Lebanon => &[("LBP", "Lebanese pound", "ل.ل")],
             Self::Lesotho => &[("ZAR", "South African rand", "R"), ("LSL", "Lesotho loti", "L")],
             Self::Liberia => &[("LRD", "Liberian dollar", "$")],
+            Self::Liberland => &[("LLD", "Liberland dollar", "LLD")],
             Self::Libya => &[("LYD", "Libyan dinar", "ل.د")],
             Self::Liechtenstein => &[("CHF", "Swiss franc", "Fr")],
             Self::Lithuania => &[("EUR", "Euro", "€")],
@@ -2416,6 +2425,7 @@ impl Country {
             Self::Lebanon => &[("fra", "French"), ("ara", "Arabic")],
             Self::Lesotho => &[("sot", "Sotho"), ("eng", "English")],
             Self::Liberia => &[("eng", "English")],
+            Self::Liberland => &[("eng", "English")],
             Self::Libya => &[("ara", "Arabic")],
             Self::Liechtenstein => &[("deu", "German")],
             Self::Lithuania => &[("lit", "Lithuanian")],
@@ -2670,6 +2680,7 @@ impl Country {
             Self::Lebanon => &["ISR", "SYR"],
             Self::Lesotho => &["ZAF"],
             Self::Liberia => &["GIN", "CIV", "SLE"],
+            Self::Liberland => &["HRV", "SRB"],
             Self::Libya => &["DZA", "TCD", "EGY", "NER", "SDN", "TUN"],
             Self::Liechtenstein => &["AUT", "CHE"],
             Self::Lithuania => &["BLR", "LVA", "POL", "RUS"],
@@ -2924,6 +2935,7 @@ impl Country {
             Self::Lebanon => &["Beirut"],
             Self::Lesotho => &["Maseru"],
             Self::Liberia => &["Monrovia"],
+            Self::Liberland => &[],
             Self::Libya => &["Tripoli"],
             Self::Liechtenstein => &["Vaduz"],
             Self::Lithuania => &["Vilnius"],
@@ -3178,6 +3190,7 @@ impl Country {
             Self::Lebanon => &[(236, 28, 36), (184, 84, 148), (240, 84, 36), (240, 84, 36), (240, 84, 36), (248, 84, 36), (8, 166, 87), (140, 220, 180), (251, 250, 250)],
             Self::Lesotho => &[(5, 5, 5), (4, 20, 139), (4, 156, 68), (132, 132, 132), (164, 164, 164), (188, 188, 188), (220, 220, 220), (244, 244, 244), (252, 252, 252)],
             Self::Liberia => &[(4, 44, 108), (188, 12, 52), (192, 12, 100), (192, 12, 100), (140, 76, 100), (204, 76, 100), (217, 132, 156), (148, 164, 188), (250, 248, 249)],
+            Self::Liberland => &[(18, 15, 20), (180, 66, 45), (60, 145, 168), (226, 137, 23), (167, 168, 26), (206, 163, 21), (248, 182, 104), (251, 211, 20), (248, 248, 248)],
             Self::Libya => &[(4, 4, 4), (32, 12, 4), (28, 12, 52), (28, 28, 28), (228, 4, 20), (60, 60, 60), (100, 100, 100), (36, 156, 68), (237, 237, 237)],
             Self::Liechtenstein => &[(4, 43, 121), (208, 12, 20), (232, 12, 20), (204, 20, 36), (92, 76, 28), (200, 60, 84), (200, 72, 20), (116, 100, 28), (214, 184, 50)],
             Self::Lithuania => &[(196, 36, 44), (4, 108, 68), (148, 116, 44), (228, 192, 44), (228, 192, 44), (228, 192, 44), (228, 192, 44), (228, 192, 44), (252, 188, 20)],
@@ -3432,6 +3445,7 @@ impl Country {
             Self::Lebanon => 10452_f64,
             Self::Lesotho => 30355_f64,
             Self::Liberia => 111369_f64,
+            Self::Liberland => 7_f64,
             Self::Libya => 1759540_f64,
             Self::Liechtenstein => 160_f64,
             Self::Lithuania => 65300_f64,
@@ -3686,6 +3700,7 @@ impl Country {
             Self::Lebanon => r###"+961"###,
             Self::Lesotho => r###"+266"###,
             Self::Liberia => r###"+231"###,
+            Self::Liberland => r###""###,
             Self::Libya => r###"+218"###,
             Self::Liechtenstein => r###"+423"###,
             Self::Lithuania => r###"+370"###,
@@ -3940,6 +3955,7 @@ impl Country {
             Self::Lebanon => r###"right"###,
             Self::Lesotho => r###"left"###,
             Self::Liberia => r###"right"###,
+            Self::Liberland => r###"right"###,
             Self::Libya => r###"right"###,
             Self::Liechtenstein => r###"right"###,
             Self::Lithuania => r###"right"###,
@@ -4194,6 +4210,7 @@ impl Country {
             Self::Lebanon => r###"🇱🇧"###,
             Self::Lesotho => r###"🇱🇸"###,
             Self::Liberia => r###"🇱🇷"###,
+            Self::Liberland => r###"🟨"###,
             Self::Libya => r###"🇱🇾"###,
             Self::Liechtenstein => r###"🇱🇮"###,
             Self::Lithuania => r###"🇱🇹"###,
@@ -4448,6 +4465,7 @@ impl Country {
             Self::Lebanon => (248, 84, 36),
             Self::Lesotho => (4, 20, 139),
             Self::Liberia => (188, 12, 52),
+            Self::Liberland => (251, 211, 20),
             Self::Libya => (228, 4, 20),
             Self::Liechtenstein => (232, 12, 20),
             Self::Lithuania => (252, 188, 20),
@@ -4702,6 +4720,7 @@ impl Country {
             Self::Lebanon => 6825442_u64,
             Self::Lesotho => 2142252_u64,
             Self::Liberia => 5057677_u64,
+            Self::Liberland => 63_u64,
             Self::Libya => 6871287_u64,
             Self::Liechtenstein => 38137_u64,
             Self::Lithuania => 2794700_u64,
@@ -4956,6 +4975,7 @@ impl Country {
             Self::Lebanon => &["Asia"],
             Self::Lesotho => &["Africa"],
             Self::Liberia => &["Africa"],
+            Self::Liberland => &["Europe"],
             Self::Libya => &["Africa"],
             Self::Liechtenstein => &["Europe"],
             Self::Lithuania => &["Europe"],
@@ -7210,6 +7230,23 @@ impl Country {
 [38;2;255;255;255m@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@[0m
 [38;2;215;102;126mvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv[0m
 [38;2;191;10;48m----------------------------------------[0m"###,
+            Country::Liberland => r###"[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddd[38;2;240;201;19mw[38;2;138;84;19m)[38;2;175;125;20mx[38;2;191;145;20mz[38;2;188;141;19mc[38;2;164;124;23mr[38;2;173;123;20mx[38;2;192;145;19mz[38;2;189;142;19mc[38;2;167;116;19mj[38;2;152;102;19m/[38;2;251;210;20mddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddd[38;2;248;208;20mp[38;2;87;20;20ml[38;2;93;21;22m!![38;2;93;47;29m~[38;2;96;73;35m][38;2;98;79;38m[[38;2;92;23;23m![38;2;93;21;22m!![38;2;119;61;19m?[38;2;251;210;20mddddddddddddddd[0m
+[38;2;185;155;15mXXXXXXXXXXXXXX[38;2;186;155;15mX[38;2;80;21;19ml[38;2;87;21;22m!![38;2;88;32;26m>[38;2;90;36;25m>[38;2;96;29;25m>[38;2;88;23;24m!![38;2;92;27;28mi[38;2;111;62;26m?[38;2;185;155;15mXXXXXXXXXXXXXXX[0m
+[38;2;0;0;0m               [38;2;192;193;193mq[38;2;255;255;255m@@@[38;2;254;255;255m$[38;2;251;251;251mB[38;2;252;232;207mW[38;2;251;212;167mo[38;2;254;252;249m$[38;2;139;139;139mv[38;2;0;0;0m               [0m
+[38;2;0;0;0m               [38;2;90;90;90m1[38;2;255;255;255m@@[38;2;243;243;243m8[38;2;104;104;104m\[38;2;164;164;164mC[38;2;249;191;124md[38;2;248;157;57mQ[38;2;244;230;213mM[38;2;38;38;38ml[38;2;0;0;0m               [0m
+[38;2;0;0;0m               [38;2;1;1;1m [38;2;161;168;173mL[38;2;161;177;190m0[38;2;60;77;90m?[38;2;27;29;32m:[38;2;98;103;108m|[38;2;213;231;244m#[38;2;222;235;246mM[38;2;102;103;104m|[38;2;0;0;0m                [0m
+[38;2;204;171;17mCCCCCCCCCCCCCCCC[38;2;195;168;26mJ[38;2;48;121;163m\[38;2;28;123;200m|[38;2;43;120;181m\[38;2;32;122;195m|[38;2;25;121;199m|[38;2;83;131;127mf[38;2;204;171;17mCCCCCCCCCCCCCCCCC[0m
+[38;2;251;210;20mddddddddddddddddd[38;2;218;190;33mO[38;2;51;124;162m\[38;2;24;120;199m|[38;2;23;120;199m|[38;2;82;132;131mf[38;2;240;203;21mq[38;2;251;210;20mddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddd[38;2;229;196;28mm[38;2;84;133;128mf[38;2;122;147;98mu[38;2;245;206;20mp[38;2;251;210;20mdddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m
+[38;2;251;210;20mdddddddddddddddddddddddddddddddddddddddd[0m"###,
             Country::Libya => r###"[38;2;231;0;19m]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]][0m
 [38;2;231;0;19m]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]][0m
 [38;2;231;0;19m]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]][0m
@@ -11464,6 +11501,23 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 ----------------------------------------"###,
+            Country::Liberland => r###"dddddddddddddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd
+ddddddddddddddw)xzcrxzcj/ddddddddddddddd
+ddddddddddddddpl!!~][!!!?ddddddddddddddd
+XXXXXXXXXXXXXXXl!!>>>!!i?XXXXXXXXXXXXXXX
+               q@@@$BWo$v               
+               1@@8\CdQMl               
+                L0?:|#M|                
+CCCCCCCCCCCCCCCCJ\|\||fCCCCCCCCCCCCCCCCC
+dddddddddddddddddO\||fqddddddddddddddddd
+ddddddddddddddddddmfupdddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd
+dddddddddddddddddddddddddddddddddddddddd"###,
             Country::Libya => r###"]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]
 ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]
 ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]
@@ -13718,6 +13772,7 @@ Q>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"###,
             "Lebanon" => Some(Self::Lebanon),
             "Lesotho" => Some(Self::Lesotho),
             "Liberia" => Some(Self::Liberia),
+            "Liberland" => Some(Self::Liberland),
             "Libya" => Some(Self::Libya),
             "Liechtenstein" => Some(Self::Liechtenstein),
             "Lithuania" => Some(Self::Lithuania),
@@ -13973,6 +14028,7 @@ Q>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"###,
             "LBN" => Some(Self::Lebanon),
             "LSO" => Some(Self::Lesotho),
             "LBR" => Some(Self::Liberia),
+            "LIB" => Some(Self::Liberland),
             "LBY" => Some(Self::Libya),
             "LIE" => Some(Self::Liechtenstein),
             "LTU" => Some(Self::Lithuania),
@@ -14228,6 +14284,7 @@ Q>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"###,
             "LB" => Some("LBN"),
             "LS" => Some("LSO"),
             "LR" => Some("LBR"),
+            "LL" => Some("LIB"),
             "LY" => Some("LBY"),
             "LI" => Some("LIE"),
             "LT" => Some("LTU"),

--- a/gen_country/tests/liberland.rs
+++ b/gen_country/tests/liberland.rs
@@ -1,0 +1,36 @@
+use gen_country::Country;
+
+#[test]
+fn resolves_liberland_from_project_codes() {
+    assert_eq!(Country::from_country_code("LIB"), Some(Country::Liberland));
+    assert_eq!(Country::country_code3_from_country_code2("LL"), Some("LIB"));
+}
+
+#[test]
+fn exposes_seeded_liberland_metadata() {
+    assert_eq!(Country::Liberland.country_name(), "Liberland");
+    assert_eq!(Country::Liberland.country_code2(), "LL");
+    assert_eq!(Country::Liberland.country_code3(), "LIB");
+    assert_eq!(Country::Liberland.population(), 63);
+    assert_eq!(Country::Liberland.area_km(), 7.0);
+    assert_eq!(
+        Country::Liberland.currencies(),
+        &[("LLD", "Liberland dollar", "LLD")]
+    );
+    assert_eq!(
+        gen_country::status_note(Country::Liberland),
+        Some("Self-proclaimed micronation on disputed territory between Croatia and Serbia"),
+    );
+}
+
+#[test]
+fn liberland_flag_matches_repo_generation_shape() {
+    let flag_plain = Country::Liberland.flag_no_color();
+    let flag_colored = Country::Liberland.flag();
+
+    assert!(flag_plain.is_ascii());
+    assert!(flag_colored.is_ascii());
+    assert_eq!(flag_plain.lines().count(), 17);
+    assert!(flag_plain.lines().all(|line| line.len() == 40));
+    assert_eq!(Country::Liberland.palette().len(), 9);
+}

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -60,7 +60,7 @@ impl CountryMethod {
             | Self::Continents => ("self", "&Self"),
             Self::FromStr | Self::FromCountryCode | Self::CountryCode3FromCountryCode2 => {
                 ("s", "&str")
-            }
+            },
         }
     }
 
@@ -87,7 +87,7 @@ impl CountryMethod {
             | Self::Continents => "        }\n    }\n",
             Self::FromStr | Self::FromCountryCode | Self::CountryCode3FromCountryCode2 => {
                 "            _ => None\n        }\n    }\n"
-            }
+            },
         }
     }
 
@@ -102,137 +102,137 @@ impl CountryMethod {
                         .as_ref()
                         .map_or_else(|| "None".to_owned(), |d| format!("Some(r###\"{d}\"###)"))
                 )
-            }
+            },
             Self::CountryName => {
                 format!(
                     "            {} => r###\"{}\"###,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.country_name
                 )
-            }
+            },
             Self::CountryCode3 => {
                 format!(
                     "            {} => r###\"{}\"###,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.country_code3
                 )
-            }
+            },
             Self::DialingCode => {
                 format!(
                     "            {} => r###\"{}\"###,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.dialing_code
                 )
-            }
+            },
             Self::DrivingSide => {
                 format!(
                     "            {} => r###\"{}\"###,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.driving_side
                 )
-            }
+            },
             Self::CountryCode2 => {
                 format!(
                     "            {} => r###\"{}\"###,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.country_code2
                 )
-            }
+            },
             Self::TopLevelDomain => {
                 format!(
                     "            {} => &[{}],\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.top_level_domains.join(", ")
                 )
-            }
+            },
             Self::Currencies => {
                 format!(
                     "            {} => &[{}],\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.currencies
                 )
-            }
+            },
             Self::Languages => {
                 format!(
                     "            {} => &[{}],\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.languages
                 )
-            }
+            },
             Self::Capital => {
                 format!(
                     "            {} => &[{}],\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.capital.join(", ")
                 )
-            }
+            },
             Self::Palette => {
                 format!(
                     "            {} => {},\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.colors
                 )
-            }
+            },
             Self::Neighbours => {
                 format!(
                     "            {} => &[{}],\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.neighbours.join(", ")
                 )
-            }
+            },
             Self::AreaKm => {
                 format!(
                     "            {} => {}_f64,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.area_km
                 )
-            }
+            },
             Self::BrightestColor => {
                 format!(
                     "            {} => {},\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.most_colorful
                 )
-            }
+            },
             Self::Emoji => {
                 format!(
                     "            {} => r###\"{}\"###,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.emoji
                 )
-            }
+            },
             Self::Population => {
                 format!(
                     "            {} => {}_u64,\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.population
                 )
-            }
+            },
             Self::Continents => {
                 format!(
                     "            {} => &[{}],\n",
                     format_args!("Self::{}", parts.enum_name),
                     parts.continents.join(", ")
                 )
-            }
+            },
             Self::FromStr => {
                 format!(
                     "            \"{}\" => Some(Self::{}),\n",
                     parts.deunicoded_name, parts.enum_name
                 )
-            }
+            },
             Self::FromCountryCode => {
                 format!(
                     "            \"{}\" => Some(Self::{}),\n",
                     parts.country_code3, parts.enum_name
                 )
-            }
+            },
             Self::CountryCode3FromCountryCode2 => {
                 format!(
                     "            \"{}\" => Some(\"{}\"),\n",
                     parts.country_code2, parts.country_code3
                 )
-            }
+            },
             Self::Flag => format!(
                 "            Country::{} => r###\"{}\"###,\n",
                 parts.enum_name, parts.flag_color
@@ -261,7 +261,7 @@ impl CountryMethod {
             Self::Population => "u64",
             Self::Continents | Self::TopLevelDomain | Self::Neighbours | Self::Capital => {
                 "&'static [&'static str]"
-            }
+            },
             Self::FromStr | Self::FromCountryCode => "Option<Self>",
             Self::CountryCode3FromCountryCode2 | Self::Description => "Option<&'static str>",
         }
@@ -349,13 +349,15 @@ pub enum Country {
 
     // Generate all country parts in parallel because it is an expensive operation
     // that also makes network requests
-    let country_parts: Vec<CountryParts> = futures::future::join_all(
+    let mut country_parts: Vec<CountryParts> = futures::future::join_all(
         countries
             .par_iter()
             .map(country_parts::generate_country_parts)
             .collect::<Vec<_>>(),
     )
     .await;
+    country_parts.push(country_parts::manual_liberland_country_parts().await);
+    country_parts.sort_unstable_by(|a, b| a.country_name.cmp(&b.country_name));
 
     // Append all the generated parts to the respective Codegen objects
     for parts in country_parts {

--- a/xtask/src/country_parts.rs
+++ b/xtask/src/country_parts.rs
@@ -1,4 +1,4 @@
-use crate::{most_colorful_color, png_url_to_ascii};
+use crate::{image_url_to_ascii, most_colorful_color};
 use deunicode::deunicode;
 use heck::ToPascalCase as _;
 
@@ -33,7 +33,7 @@ pub async fn generate_country_parts(country: &countryfetch::Country) -> CountryP
     let deunicoded_name = deunicode(country_name);
     let enum_name = deunicoded_name.to_pascal_case();
 
-    let (flag_color, flag_nocolor, colors) = png_url_to_ascii(&country.flag.url).await.unwrap();
+    let (flag_color, flag_nocolor, colors) = image_url_to_ascii(&country.flag.url).await.unwrap();
 
     let most_colorful = most_colorful_color(&colors);
     let most_colorful = format!(
@@ -114,5 +114,52 @@ pub async fn generate_country_parts(country: &countryfetch::Country) -> CountryP
         emoji: country.emoji.clone(),
         population: country.population,
         continents,
+    }
+}
+
+const LIBERLAND_FLAG_URL: &str =
+    "https://www.comprarbanderas.es/images/banderas/400/21183-liberland_400px.jpg";
+
+pub async fn manual_liberland_country_parts() -> CountryParts {
+    let (flag_color, flag_nocolor, colors) = image_url_to_ascii(LIBERLAND_FLAG_URL).await.unwrap();
+    let most_colorful = most_colorful_color(&colors);
+    let most_colorful = format!(
+        "({}, {}, {})",
+        most_colorful.r, most_colorful.g, most_colorful.b
+    );
+    let colors = format!(
+        "&[{}]",
+        colors
+            .into_iter()
+            .map(|color| format!("({}, {}, {})", color.r, color.g, color.b))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    CountryParts {
+        enum_name: "Liberland".to_owned(),
+        deunicoded_name: "Liberland".to_owned(),
+        capital: Vec::new(),
+        dialing_code: String::new(),
+        driving_side: "right".to_owned(),
+        country_name: "Liberland".to_owned(),
+        country_code2: "LL".to_owned(),
+        most_colorful,
+        country_code3: "LIB".to_owned(),
+        flag_color,
+        flag_nocolor,
+        colors,
+        description: Some(
+            "The flag of Liberland has black-yellow-black horizontal bands with the coat of arms centered on the yellow band."
+                .to_owned(),
+        ),
+        top_level_domains: Vec::new(),
+        currencies: "(\"LLD\", \"Liberland dollar\", \"LLD\")".to_owned(),
+        languages: "(\"eng\", \"English\")".to_owned(),
+        neighbours: vec!["\"HRV\"".to_owned(), "\"SRB\"".to_owned()],
+        area_km: 7.0,
+        emoji: "🟨".to_owned(),
+        population: 63,
+        continents: vec!["\"Europe\"".to_owned()],
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -35,11 +35,13 @@ fn most_colorful_color(colors: &[palette_extract::Color]) -> palette_extract::Co
         .expect("There is at least 1 color")
 }
 
-/// Given a URL to a .png file, convert the file into colored Ascii
-async fn png_url_to_ascii(png_url: &str) -> Result<(String, String, Vec<palette_extract::Color>)> {
-    let pixels: Vec<u8> = reqwest::get(png_url).await?.bytes().await?.to_vec();
+/// Given a URL to an image file, convert it into colored Ascii
+async fn image_url_to_ascii(
+    image_url: &str,
+) -> Result<(String, String, Vec<palette_extract::Color>)> {
+    let pixels: Vec<u8> = reqwest::get(image_url).await?.bytes().await?.to_vec();
 
-    let image = image::load_from_memory_with_format(&pixels, image::ImageFormat::Png)?;
+    let image = image::load_from_memory_with_format(&pixels, image::guess_format(&pixels)?)?;
 
     let pixels = image.to_rgb8().into_raw();
 


### PR DESCRIPTION
# Add Liberland as a generated project-local country entry

## Summary

This PR adds Liberland support to `countryfetch` and keeps it stable across future code generation runs.

Liberland is not present in the upstream Rest Countries dataset that powers this project, so this change seeds a manual generated entry and wires it through the same lookup and display pat
hs as the rest of the catalog. The result is that `countryfetch Liberland` and `countryfetch ll` now render a complete entry instead of failing lookup.

## What changed

- Added Liberland to the generated country catalog with project-local lookup codes:
  - `LL` as the 2-letter alias
  - `LIB` as the 3-letter project-local code
- Added Liberland metadata to `gen_country`, including:
  - name
  - area
  - population
  - continent
  - neighbours                                                                                                                                                                                - language
  - established date
  - currency                                                                                                                                                                                  - generated flag art / palette
- Added a `status_note()` helper and surfaced it in the formatter so Liberland is clearly labeled as a self-proclaimed micronation on disputed territory between Croatia and Serbia.        - Taught the formatter to omit blank sections instead of printing empty labels. This matters for Liberland because there is no stable capital, dialing code, or TLD value to show here.
- Added tests for:
  - CLI parsing by name (`Liberland`)
  - CLI parsing by alias (`ll`)
  - generated code lookups for `LL` and `LIB`
  - rendered output content and omission of unknown fields
  - flag shape / encoding expectations for the checked-in Liberland art
- Updated the README usage examples and added an unreleased changelog entry.

## Why this approach

Liberland cannot be added by relying on the upstream dataset alone. If we only patched the checked-in generated file, the entry would disappear the next time the generator was run. This PR
 instead adds a manual overlay in the generator source and keeps the generated output in sync, so the branch remains maintainable.

I also intentionally avoided inventing placeholder values for fields that are not stable or not officially established. Instead of printing noisy blanks like `Capital:` or `Dialing code:`,
 the formatter now skips empty sections cleanly.

## Validation

Ran and passed:

- `cargo test --workspace`
- `cargo run -q -p countryfetch -- Liberland --no-flag --no-palette --no-color`
- `cargo run -q -p countryfetch -- ll --no-flag --no-palette --no-color`

Observed CLI output now includes:

- `Liberland 🟨`
- `ISO Codes: LL / LIB`
- `Established: April 13, 2015`
- `Status: Self-proclaimed micronation on disputed territory between Croatia and Serbia`
- `Population: 63 People`
- `Currency: LLD (Liberland dollar)`

## Notes

- `LL` / `LIB` are project-local identifiers used so the entry can participate in existing lookup/display code paths without pretending Liberland has official ISO assignment in the upstream dataset.
- The status wording is intentional, because Liberland is not a UN-recognized sovereign state and the surrounding territory is disputed.
- `LLD` is treated as the displayed currency here; `LLM` is not surfaced as the primary currency line because Liberland's own documentation describes it as the governance / merit token rather than the transactional dollar token.
- Liberland's checked-in flag output is generated from a project-local image source using the repository's existing image-to-ASCII path at `40` columns by `17` rows, producing both a no-color ASCII variant and a colored ANSI variant.
- Metadata and wording were cross-checked against current public references:
  - https://simple.wikipedia.org/wiki/Liberland
  - https://docs.liberland.org/blockchain/white-paper
